### PR TITLE
ルーティングを設定

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "messages#index"
   resources :users, only: [:edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
# What
グループ機能のルーティングを定義。
新規作成機能、編集機能で構成のため、
routes.rbに: new、create、edit、updateを記述。
# Why
本アプリケーションのグループ機能実装のため